### PR TITLE
Fix dark-mode visibility on Find Help search input + branch updates

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,10 @@
       "Bash(git commit -m 'fix: upgrade Cloud Functions runtime to Node.js 20 *)",
       "Bash(git commit -m 'feat: remove Terms page from user flow *)",
       "Bash(git commit -m 'fix: remove duplicate OTP send from AuthPage — OtpVerificationPage handles it on mount *)",
-      "Bash(git commit -m 'chore: add background image and functions lockfile *)"
+      "Bash(git commit -m 'chore: add background image and functions lockfile *)",
+      "Bash(npx eslint *)",
+      "Bash(git stash *)",
+      "Bash(npx vite *)"
     ]
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,64 +4,70 @@ service cloud.firestore {
 
     /* ── Helpers ── */
     function isAuth()     { return request.auth != null; }
+    /* A real (non-anonymous) account. Guests browse via Firebase Anonymous Auth,
+       which passes isAuth() for READS but must never be allowed to WRITE.
+       isMember() already implies isAuth() (request.auth != null). */
+    function isMember() {
+      return request.auth != null &&
+        request.auth.token.firebase.sign_in_provider != 'anonymous';
+    }
     function isOwner(uid) { return request.auth.uid == uid; }
     function isAdmin() {
-      return isAuth() &&
+      return isMember() &&
         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
     }
 
     /* ── Users ── */
     match /users/{userId} {
       allow read: if isAuth();
-      allow create: if isOwner(userId);
-      allow delete: if isOwner(userId) || isAdmin();
-      allow update: if isOwner(userId) || isAdmin()
-        || (isAuth() &&
-            request.resource.data.diff(resource.data).affectedKeys()
-              .hasOnly(['networksCount', 'isMentor', 'isMentee']));
+      allow create: if isMember() && isOwner(userId);
+      allow delete: if isMember() && (isOwner(userId) || isAdmin());
+      allow update: if isMember() && (isOwner(userId) || isAdmin()
+        || request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['networksCount', 'isMentor', 'isMentee']));
     }
 
     /* ── Posts ── */
     match /posts/{postId} {
       allow read:   if isAuth();
-      allow create: if isAuth() && request.resource.data.authorId == request.auth.uid;
-      allow update: if isAuth();
-      allow delete: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow create: if isMember() && request.resource.data.authorId == request.auth.uid;
+      allow update: if isMember();
+      allow delete: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
 
       match /comments/{commentId} {
         allow read:   if isAuth();
-        allow create: if isAuth() && request.resource.data.authorId == request.auth.uid;
-        allow update: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
-        allow delete: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
+        allow create: if isMember() && request.resource.data.authorId == request.auth.uid;
+        allow update: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
+        allow delete: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
       }
     }
 
     /* ── Conversations ── */
     match /conversations/{convId} {
       allow read:   if isAuth() && (request.auth.uid in resource.data.participants || isAdmin());
-      allow create: if isAuth() && request.auth.uid in request.resource.data.participants;
-      allow update: if isAuth() && request.auth.uid in resource.data.participants;
+      allow create: if isMember() && request.auth.uid in request.resource.data.participants;
+      allow update: if isMember() && request.auth.uid in resource.data.participants;
       allow delete: if isAdmin();
 
       match /messages/{msgId} {
         allow read:   if isAuth() && request.auth.uid in get(/databases/$(database)/documents/conversations/$(convId)).data.participants;
-        allow create: if isAuth() &&
+        allow create: if isMember() &&
           request.resource.data.senderId == request.auth.uid &&
           request.auth.uid in get(/databases/$(database)/documents/conversations/$(convId)).data.participants;
-        allow update: if isAuth() &&
+        allow update: if isMember() &&
           request.auth.uid in get(/databases/$(database)/documents/conversations/$(convId)).data.participants;
-        allow delete: if isAuth() && (resource.data.senderId == request.auth.uid || isAdmin());
+        allow delete: if isMember() && (resource.data.senderId == request.auth.uid || isAdmin());
       }
     }
 
     /* ── Help requests ── */
     match /helpRequests/{docId} {
       allow read:   if isAuth();
-      allow create: if isAuth() && request.auth.uid == request.resource.data.fromUserId;
-      allow update: if isAuth() &&
+      allow create: if isMember() && request.auth.uid == request.resource.data.fromUserId;
+      allow update: if isMember() &&
         (request.auth.uid == resource.data.toUserId ||
          request.auth.uid == resource.data.fromUserId || isAdmin());
-      allow delete: if isAuth() &&
+      allow delete: if isMember() &&
         (request.auth.uid == resource.data.fromUserId ||
          request.auth.uid == resource.data.toUserId || isAdmin());
     }
@@ -69,77 +75,77 @@ service cloud.firestore {
     /* ── Networks (connection system) ── */
     match /networks/{docId} {
       allow read:   if isAuth();
-      allow create: if isAuth() && request.resource.data.fromUserId == request.auth.uid;
-      allow delete: if isAuth() && resource.data.fromUserId == request.auth.uid;
+      allow create: if isMember() && request.resource.data.fromUserId == request.auth.uid;
+      allow delete: if isMember() && resource.data.fromUserId == request.auth.uid;
     }
 
     /* ── Reviews ── */
     match /reviews/{reviewId} {
       allow read:   if isAuth();
-      allow create: if isAuth() && request.resource.data.reviewerId == request.auth.uid;
+      allow create: if isMember() && request.resource.data.reviewerId == request.auth.uid;
     }
 
     /* ── OTPs ── */
     match /otps/{uid} {
-      allow read, write: if isAuth() && isOwner(uid);
+      allow read, write: if isMember() && isOwner(uid);
     }
 
     /* ── Notifications ── */
     match /notifications/{userId}/items/{notifId} {
       allow read:   if isAuth() && isOwner(userId);
-      allow create: if isAuth();
-      allow update: if isAuth() && (isOwner(userId) || isAdmin());
-      allow delete: if isAuth() && (isOwner(userId) || isAdmin());
+      allow create: if isMember();
+      allow update: if isMember() && (isOwner(userId) || isAdmin());
+      allow delete: if isMember() && (isOwner(userId) || isAdmin());
     }
 
     /* ── Events ── */
     match /events/{eventId} {
       allow read:   if isAuth();
-      allow create: if isAuth();
-      allow update: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
-      allow delete: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow create: if isMember();
+      allow update: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow delete: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
     }
 
     /* ── Jobs ── */
     match /jobs/{jobId} {
       allow read:   if isAuth();
-      allow create: if isAuth();
-      allow update: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
-      allow delete: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow create: if isMember();
+      allow update: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow delete: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
     }
 
     /* ── Groups ── */
     match /groups/{groupId} {
       allow read:   if isAuth();
-      allow create: if isAuth();
-      allow update: if isAuth();
-      allow delete: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow create: if isMember();
+      allow update: if isMember();
+      allow delete: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
     }
 
     /* ── Mentorship requests ── */
     match /mentorRequests/{reqId} {
       allow read:   if isAuth() && (resource.data.mentorId == request.auth.uid || resource.data.menteeId == request.auth.uid || isAdmin());
-      allow create: if isAuth();
-      allow update: if isAuth() && (resource.data.mentorId == request.auth.uid || resource.data.menteeId == request.auth.uid);
-      allow delete: if isAuth() && (resource.data.mentorId == request.auth.uid || resource.data.menteeId == request.auth.uid || isAdmin());
+      allow create: if isMember();
+      allow update: if isMember() && (resource.data.mentorId == request.auth.uid || resource.data.menteeId == request.auth.uid);
+      allow delete: if isMember() && (resource.data.mentorId == request.auth.uid || resource.data.menteeId == request.auth.uid || isAdmin());
     }
 
     /* ── Stories ── */
     match /stories/{storyId} {
       allow read:   if isAuth();
-      allow create: if isAuth() && request.resource.data.authorId == request.auth.uid;
-      allow delete: if isAuth() && (resource.data.authorId == request.auth.uid || isAdmin());
+      allow create: if isMember() && request.resource.data.authorId == request.auth.uid;
+      allow delete: if isMember() && (resource.data.authorId == request.auth.uid || isAdmin());
     }
 
     /* ── Activity logs ── */
     match /activityLogs/{logId} {
-      allow create: if isAuth();
+      allow create: if isMember();
       allow read:   if isAdmin();
     }
 
     /* ── Reports ── */
     match /reports/{reportId} {
-      allow create: if isAuth() && request.resource.data.reporterId == request.auth.uid;
+      allow create: if isMember() && request.resource.data.reporterId == request.auth.uid;
       allow read, update, delete: if isAdmin();
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "firebase": "^12.13.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1651,6 +1652,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1783,6 +1793,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1795,6 +1818,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1821,6 +1853,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2233,6 +2277,15 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3118,6 +3171,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3350,6 +3415,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3375,6 +3458,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "firebase": "^12.13.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/AdminPage.jsx
+++ b/frontend/src/AdminPage.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import * as XLSX from "xlsx";
 import {
   collection, getDocs, deleteDoc, doc, query,
   orderBy, updateDoc, limit, where,
@@ -42,6 +43,18 @@ const AT = {
       canSendAnnouncements:"שליחת הודעות לקהילה",
       canExportData:"ייצוא נתונים",
     },
+    downloadExcel:"הורדה לאקסל", uploadData:"העלאת נתונים",
+    exportTitle:"בחרי שדות לייצוא", exportSub:"סמני אילו עמודות לכלול בקובץ האקסל",
+    selectAllFields:"בחרי הכל", clearAllFields:"נקי הכל",
+    exportSelectedBtn:(n)=>`ייצוא ${n} שדות`, noFieldsSelected:"לא נבחרו שדות לייצוא.",
+    downloading:"מוריד...", uploading:"מעלה...",
+    downloadSuccess:"הקובץ הורד בהצלחה!", uploadSuccess:(n)=>`${n} שורות עודכנו בהצלחה!`,
+    uploadError:"שגיאה בהעלאת הקובץ.", downloadError:"שגיאה בהורדת הקובץ.",
+    invalidFileType:"סוג קובץ לא חוקי. אנא העלי קובץ אקסל אמיתי (.xlsx או .xls) בלבד.",
+    corruptedFile:"הקובץ פגום או שאינו ניתן לקריאה.",
+    emptyFile:"הקובץ ריק — לא נמצאו שורות.",
+    missingEmailCol:"עמודת 'email' חסרה בקובץ.",
+    skippedRows:(n)=>`${n} שורות דולגו (אימייל לא נמצא במערכת).`,
     showDataTab:"נתונים", reportsTab:"דיווחים",
     noReports:"אין דיווחים עדיין.", reportFrom:"דווח ע\"י", reportedUser:"משתמשת מדווחת",
     reportReason:"סיבה", reportDate:"תאריך", reportStatus:"סטטוס",
@@ -99,6 +112,18 @@ const AT = {
       canSendAnnouncements:"Send Community Announcements",
       canExportData:"Export Data",
     },
+    downloadExcel:"Download to Excel", uploadData:"Upload Data",
+    exportTitle:"Select Fields to Export", exportSub:"Choose which columns to include in the Excel file",
+    selectAllFields:"Select All", clearAllFields:"Clear All",
+    exportSelectedBtn:(n)=>`Export ${n} field${n===1?"":"s"}`, noFieldsSelected:"No fields selected for export.",
+    downloading:"Downloading…", uploading:"Uploading…",
+    downloadSuccess:"File downloaded successfully!", uploadSuccess:(n)=>`${n} rows updated successfully!`,
+    uploadError:"Error uploading file.", downloadError:"Error downloading file.",
+    invalidFileType:"Invalid file type. Please upload a real Excel file (.xlsx or .xls) only.",
+    corruptedFile:"The file is corrupted or unreadable.",
+    emptyFile:"The file is empty — no rows found.",
+    missingEmailCol:"'email' column is missing from the file.",
+    skippedRows:(n)=>`${n} rows skipped (email not found in system).`,
     showDataTab:"Data", reportsTab:"Reports",
     noReports:"No reports yet.", reportFrom:"Reported by", reportedUser:"Reported user",
     reportReason:"Reason", reportDate:"Date", reportStatus:"Status",
@@ -156,6 +181,18 @@ const AT = {
       canSendAnnouncements:"إرسال إعلانات للمجتمع",
       canExportData:"تصدير البيانات",
     },
+    downloadExcel:"تنزيل إلى إكسل", uploadData:"رفع بيانات",
+    exportTitle:"اختاري الحقول للتصدير", exportSub:"اختاري الأعمدة التي تريدين تضمينها في ملف إكسل",
+    selectAllFields:"تحديد الكل", clearAllFields:"مسح الكل",
+    exportSelectedBtn:(n)=>`تصدير ${n} حقول`, noFieldsSelected:"لم يتم تحديد أي حقول للتصدير.",
+    downloading:"جارٍ التنزيل…", uploading:"جارٍ الرفع…",
+    downloadSuccess:"تم تنزيل الملف بنجاح!", uploadSuccess:(n)=>`تم تحديث ${n} صفوف بنجاح!`,
+    uploadError:"خطأ في رفع الملف.", downloadError:"خطأ في تنزيل الملف.",
+    invalidFileType:"نوع ملف غير صالح. يرجى رفع ملف إكسل حقيقي (.xlsx أو .xls) فقط.",
+    corruptedFile:"الملف تالف أو غير قابل للقراءة.",
+    emptyFile:"الملف فارغ — لم يتم العثور على صفوف.",
+    missingEmailCol:"عمود 'email' مفقود من الملف.",
+    skippedRows:(n)=>`تم تخطي ${n} صفوف (البريد الإلكتروني غير موجود في النظام).`,
     showDataTab:"البيانات", reportsTab:"البلاغات",
     noReports:"لا توجد بلاغات بعد.", reportFrom:"مُبلَّغ من قِبَل", reportedUser:"المستخدمة المُبلَّغ عنها",
     reportReason:"السبب", reportDate:"التاريخ", reportStatus:"الحالة",
@@ -348,6 +385,39 @@ const S = {
     fontSize: "12px", fontWeight: 700, cursor: "pointer",
     transition: "background 0.15s",
   },
+  /* Excel buttons */
+  excelBtn: {
+    display: "inline-flex", alignItems: "center", gap: "6px",
+    padding: "8px 18px", borderRadius: "10px",
+    fontSize: "12px", fontWeight: 700, cursor: "pointer",
+    fontFamily: "var(--font,'Figtree','Heebo',system-ui,sans-serif)",
+    transition: "all 0.18s",
+    border: "1.5px solid #bfdbfe", background: "#eff6ff", color: "#1d4896",
+  },
+  excelBtnUpload: {
+    display: "inline-flex", alignItems: "center", gap: "6px",
+    padding: "8px 18px", borderRadius: "10px",
+    fontSize: "12px", fontWeight: 700, cursor: "pointer",
+    fontFamily: "var(--font,'Figtree','Heebo',system-ui,sans-serif)",
+    transition: "all 0.18s",
+    border: "1.5px solid #a3d9a5", background: "#f0fdf4", color: "#166534",
+  },
+  /* Toast */
+  toastWrap: {
+    position: "fixed", bottom: "2rem", left: "50%", transform: "translateX(-50%)",
+    zIndex: 999, pointerEvents: "none",
+  },
+  toastBox: (variant) => ({
+    pointerEvents: "auto",
+    padding: "12px 22px", borderRadius: "14px",
+    fontSize: "13px", fontWeight: 700,
+    display: "flex", alignItems: "center", gap: "10px",
+    boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+    animation: "slideUp 0.35s ease both",
+    background: variant === "success" ? "#e2efe1" : variant === "error" ? "#f5dada" : "#dbeafe",
+    color: variant === "success" ? "#3f6a3e" : variant === "error" ? "#c25c5c" : "#1d4896",
+    border: variant === "success" ? "1.5px solid #cfe4ce" : variant === "error" ? "1.5px solid #d99090" : "1.5px solid #bfdbfe",
+  }),
   logFilterInput: {
     padding: "7px 12px", fontSize: "12px",
     border: "1.5px solid var(--border,#f0dce0)", borderRadius: "9px",
@@ -413,6 +483,31 @@ function SectionHeader({ title, count, action }) {
   );
 }
 
+/* ── Toast notification ── */
+function Toast({ message, variant, onClose }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 4500);
+    return () => clearTimeout(t);
+  }, [onClose]);
+  return (
+    <div style={S.toastWrap}>
+      <div style={S.toastBox(variant)}>
+        {variant === "success" ? (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        ) : variant === "error" ? (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+        ) : (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        )}
+        <span>{message}</span>
+        <button onClick={onClose} style={{ background:"none", border:"none", cursor:"pointer", color:"inherit", padding:"2px", marginLeft:"4px", lineHeight:1 }}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /* ─── Log type config ─── */
 const LOG_TYPES = {
   signup:               { label: "SIGNUP",         bg: "#e2efe1", color: "#3f6a3e", borderColor: "#7ba87a" },
@@ -468,6 +563,41 @@ function formatAbsoluteTime(ts) {
 /* ─── Permission keys ─── */
 const PERM_KEYS = ["canManageUsers","canManageContent","canViewLogs","canManageAdmins","canViewStats","canSendAnnouncements","canExportData"];
 const DEFAULT_PERMS = Object.fromEntries(PERM_KEYS.map(k => [k, false]));
+
+/* ─── Excel export fields config (shared by download + selection modal) ─── */
+const EXPORT_FIELDS = [
+  { key:"firstName",          label:"First Name" },
+  { key:"lastName",           label:"Last Name" },
+  { key:"email",              label:"Email" },
+  { key:"phone",              label:"Phone" },
+  { key:"birthdate",          label:"Birthdate" },
+  { key:"region",             label:"Region" },
+  { key:"city",               label:"City" },
+  { key:"profession",         label:"Profession" },
+  { key:"campus",             label:"Campus" },
+  { key:"bachelorDegree",     label:"Bachelor Degree" },
+  { key:"masterDegree",       label:"Master Degree" },
+  { key:"phdDegree",          label:"PhD Degree" },
+  { key:"currentRole",        label:"Current Role" },
+  { key:"employmentSectors",  label:"Employment Sectors" },
+  { key:"governmentMinistry", label:"Government Ministry" },
+  { key:"localAuthority",     label:"Local Authority" },
+  { key:"partyAffiliation",   label:"Party Affiliation" },
+  { key:"publicRoles",        label:"Public Roles" },
+  { key:"helpAreas",          label:"Help Areas" },
+  { key:"wantToReceive",      label:"Wants to Receive" },
+  { key:"mentoringRole",      label:"Mentoring Role" },
+  { key:"linkedin",           label:"LinkedIn" },
+  { key:"instagram",          label:"Instagram" },
+  { key:"facebook",           label:"Facebook" },
+  { key:"tagline",            label:"Tagline" },
+  { key:"bio",                label:"Bio" },
+  { key:"_religiousIdentity", label:"Religious Identity" },
+  { key:"_communityEthnicity",label:"Community / Ethnicity" },
+  { key:"emailVerified",      label:"Email Verified" },
+  { key:"isAdmin",            label:"Is Admin" },
+  { key:"createdAt",          label:"Created At" },
+];
 
 /* ── Simple confirm modal ── */
 function ConfirmModal({ title, message, confirmLabel, onConfirm, onCancel, danger = true }) {
@@ -538,6 +668,91 @@ function PermissionsModal({ user: u, isNew, onSave, onCancel, Tr }) {
           <button style={S.cancelModalBtn} onClick={onCancel}>{Tr?.cancel}</button>
           <button style={{ ...S.saveModalBtn, opacity: saving ? 0.7 : 1 }} onClick={handleSave} disabled={saving}>
             {saving ? Tr?.saving : (isNew ? Tr?.savePerms : Tr?.updatePerms)}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════════════════
+   EXPORT FIELD-SELECTION MODAL
+   Lets the admin pick exactly which columns to include
+   in the Excel export before downloading.
+═══════════════════════════════════════════════════════ */
+function ExportFieldsModal({ busy, onExport, onCancel, Tr }) {
+  /* Selected = set of field keys. Default: everything checked. */
+  const [selected, setSelected] = useState(() => new Set(EXPORT_FIELDS.map(f => f.key)));
+
+  const toggle = (key) =>
+    setSelected(prev => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+
+  const selectAll = () => setSelected(new Set(EXPORT_FIELDS.map(f => f.key)));
+  const clearAll  = () => setSelected(new Set());
+
+  const count = selected.size;
+
+  const handleExport = () => {
+    if (count === 0) return;
+    /* Preserve the canonical field order from EXPORT_FIELDS */
+    onExport(EXPORT_FIELDS.filter(f => selected.has(f.key)).map(f => f.key));
+  };
+
+  return (
+    <div style={S.overlay} onClick={onCancel}>
+      <div style={{ ...S.modalBox, maxWidth: 520 }} onClick={e => e.stopPropagation()}>
+        <p style={S.modalTitle}>{Tr?.exportTitle}</p>
+        <p style={{ fontSize: 13, color: "var(--text-muted,#6b7280)", margin: "0 0 0.25rem" }}>{Tr?.exportSub}</p>
+
+        {/* Select-all / clear-all bar */}
+        <div style={{ display: "flex", gap: 8, marginBottom: "0.25rem" }}>
+          <button type="button" onClick={selectAll} style={{ ...S.refreshBtn, padding: "5px 12px" }}>
+            {Tr?.selectAllFields}
+          </button>
+          <button type="button" onClick={clearAll} style={{ ...S.refreshBtn, padding: "5px 12px", background: "var(--bg-tertiary,#f0f6fb)", border: "1.5px solid var(--border,#daeaf8)", color: "var(--text-muted,#6b7280)" }}>
+            {Tr?.clearAllFields}
+          </button>
+        </div>
+
+        {/* Field checkboxes — 2-column grid, same checkbox visual as PermissionsModal */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, maxHeight: "48vh", overflowY: "auto", paddingRight: 4 }}>
+          {EXPORT_FIELDS.map(({ key, label }) => {
+            const on = selected.has(key);
+            return (
+              <label key={key} onClick={() => toggle(key)} style={{
+                display: "flex", alignItems: "center", gap: 10, padding: "8px 12px",
+                borderRadius: 10, cursor: "pointer",
+                background: on ? "rgba(68,114,184,0.08)" : "var(--bg-secondary,#f0f6fb)",
+                border: on ? "1.5px solid rgba(68,114,184,0.3)" : "1.5px solid transparent",
+                transition: "all 0.15s",
+              }}>
+                <div style={{
+                  width: 18, height: 18, borderRadius: 5, flexShrink: 0,
+                  background: on ? "var(--brand,#4472b8)" : "var(--bg-tertiary,#daeaf8)",
+                  border: on ? "none" : "1.5px solid #b0c4de",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  transition: "all 0.15s",
+                }}>
+                  {on && <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>}
+                </div>
+                <span style={{ fontSize: 12.5, fontWeight: on ? 700 : 500, color: "var(--text-primary,#111827)" }}>{label}</span>
+              </label>
+            );
+          })}
+        </div>
+
+        <div style={S.modalActions}>
+          <button style={S.cancelModalBtn} onClick={onCancel} disabled={busy}>{Tr?.cancel}</button>
+          <button
+            style={{ ...S.saveModalBtn, opacity: (busy || count === 0) ? 0.6 : 1, cursor: (busy || count === 0) ? "not-allowed" : "pointer" }}
+            onClick={handleExport}
+            disabled={busy || count === 0}
+          >
+            {busy ? Tr?.downloading : (count === 0 ? Tr?.noFieldsSelected : Tr?.exportSelectedBtn?.(count))}
           </button>
         </div>
       </div>
@@ -666,6 +881,15 @@ export default function AdminPage() {
   const [convs, setConvs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchUser, setSearchUser] = useState("");
+
+  /* ── Toast state ── */
+  const [toast, setToast] = useState(null); // { message, variant }
+  const showToast = useCallback((message, variant = "success") => setToast({ message, variant }), []);
+
+  /* ── Excel refs ── */
+  const fileInputRef = useRef(null);
+  const [excelBusy, setExcelBusy] = useState(false);
+  const [exportModalOpen, setExportModalOpen] = useState(false);
 
   /* ── Edit Users tab state ── */
   const [userSearch, setUserSearch] = useState("");
@@ -888,6 +1112,168 @@ export default function AdminPage() {
       });
     } catch (err) { console.error("Admin delete comment error:", err); }
   };
+
+  /* ── Download to Excel (only the admin-selected fields) ── */
+  const handleDownloadExcel = useCallback((selectedKeys) => {
+    /* Fall back to all fields if called without a selection */
+    const keys = (selectedKeys && selectedKeys.length)
+      ? selectedKeys
+      : EXPORT_FIELDS.map(f => f.key);
+    const fields = EXPORT_FIELDS.filter(f => keys.includes(f.key));
+
+    setExcelBusy(true);
+    try {
+      const rows = users.map(u => {
+        const row = {};
+        fields.forEach(({ key, label }) => {
+          const val = u[key];
+          if (Array.isArray(val)) row[label] = val.join("; ");
+          else if (typeof val === "boolean") row[label] = val ? "Yes" : "No";
+          else row[label] = val ?? "";
+        });
+        return row;
+      });
+      const ws = XLSX.utils.json_to_sheet(rows);
+      /* Set column widths (per selected field, same order) */
+      ws["!cols"] = fields.map(({ key }) => ({
+        wch: key === "bio" ? 40 : key === "email" ? 28 : key === "helpAreas" || key === "employmentSectors" ? 50 : 20,
+      }));
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, "Users");
+      const date = new Date().toISOString().slice(0,10);
+      /* Force a TRUE native .xlsx (OOXML) — bookType pinned so the format is
+         never inferred from the name nor written as renamed CSV. */
+      XLSX.writeFile(wb, `kehila_users_${date}.xlsx`, { bookType: "xlsx", compression: true });
+      showToast(Tr.downloadSuccess, "success");
+      logActivity({
+        type: "admin_export_data", actorId: user.uid, actorName: adminName,
+        details: { rowCount: users.length, fields: keys },
+      });
+      setExportModalOpen(false);
+    } catch (err) {
+      console.error("Download error:", err);
+      showToast(Tr.downloadError, "error");
+    } finally {
+      setExcelBusy(false);
+    }
+  }, [users, Tr, user, adminName, showToast]);
+
+  /* ── Upload — STRICTLY true Excel files (.xlsx / .xls) only ── */
+  const handleUploadExcel = useCallback(async (e) => {
+    const file = e.target.files?.[0];
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (!file) return;
+
+    /* Gate 1: extension must be .xlsx or .xls (no .csv) */
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    if (ext !== "xlsx" && ext !== "xls") {
+      showToast(Tr.invalidFileType, "error");
+      return;
+    }
+
+    setExcelBusy(true);
+    try {
+      const data = await file.arrayBuffer();
+
+      /* Gate 2: verify the BINARY signature so a renamed .csv can't slip
+         through. A real .xlsx is a ZIP archive (starts with "PK", 50 4B);
+         a real .xls is an OLE2 compound file (D0 CF 11 E0). Anything else
+         (e.g. a CSV renamed to .xlsx) is rejected before parsing. */
+      const sig = new Uint8Array(data.slice(0, 4));
+      const isXlsx = sig[0] === 0x50 && sig[1] === 0x4b;                              // PK..
+      const isXls  = sig[0] === 0xd0 && sig[1] === 0xcf && sig[2] === 0x11 && sig[3] === 0xe0; // OLE2
+      if (!isXlsx && !isXls) {
+        showToast(Tr.invalidFileType, "error");
+        setExcelBusy(false);
+        return;
+      }
+
+      let wb;
+      try {
+        /* Pin the type so SheetJS never falls back to CSV/text parsing */
+        wb = XLSX.read(data, { type: "array", codepage: 65001 });
+      } catch {
+        showToast(Tr.corruptedFile, "error");
+        setExcelBusy(false);
+        return;
+      }
+
+      const sheetName = wb.SheetNames[0];
+      if (!sheetName) { showToast(Tr.emptyFile, "error"); setExcelBusy(false); return; }
+
+      const rows = XLSX.utils.sheet_to_json(wb.Sheets[sheetName], { defval: "" });
+      if (rows.length === 0) { showToast(Tr.emptyFile, "error"); setExcelBusy(false); return; }
+
+      /* Build a reverse label→key map */
+      const labelToKey = {};
+      EXPORT_FIELDS.forEach(({ key, label }) => { labelToKey[label.toLowerCase()] = key; });
+
+      /* Check for email column */
+      const headerKeys = Object.keys(rows[0]).map(h => h.toLowerCase());
+      if (!headerKeys.includes("email")) {
+        showToast(Tr.missingEmailCol, "error");
+        setExcelBusy(false);
+        return;
+      }
+
+      /* Build email→userId map from existing users */
+      const emailToUser = {};
+      users.forEach(u => { if (u.email) emailToUser[u.email.toLowerCase().trim()] = u; });
+
+      const ARRAY_FIELDS = new Set(["employmentSectors", "helpAreas"]);
+      const BOOL_FIELDS = new Set(["emailVerified", "isAdmin"]);
+      const READONLY_FIELDS = new Set(["createdAt", "emailVerified", "isAdmin"]);
+
+      let updatedCount = 0;
+      let skippedCount = 0;
+
+      for (const row of rows) {
+        /* Find email value (case-insensitive header match) */
+        const emailHeader = Object.keys(row).find(h => h.toLowerCase() === "email");
+        const email = (row[emailHeader] || "").toString().toLowerCase().trim();
+        if (!email) { skippedCount++; continue; }
+
+        const existingUser = emailToUser[email];
+        if (!existingUser) { skippedCount++; continue; }
+
+        /* Build update payload */
+        const updates = {};
+        Object.entries(row).forEach(([header, val]) => {
+          const fieldKey = labelToKey[header.toLowerCase()];
+          if (!fieldKey || READONLY_FIELDS.has(fieldKey)) return;
+          if (ARRAY_FIELDS.has(fieldKey)) {
+            updates[fieldKey] = typeof val === "string" ? val.split(";").map(s => s.trim()).filter(Boolean) : [];
+          } else if (BOOL_FIELDS.has(fieldKey)) {
+            updates[fieldKey] = val === true || val === "Yes" || val === "yes" || val === "TRUE" || val === "true";
+          } else {
+            updates[fieldKey] = val === "" ? null : val;
+          }
+        });
+
+        if (Object.keys(updates).length > 0) {
+          await updateDoc(doc(db, "users", existingUser.id), updates);
+          /* Update local state */
+          setUsers(prev => prev.map(u => u.id === existingUser.id ? { ...u, ...updates } : u));
+          updatedCount++;
+        }
+      }
+
+      /* Log activity */
+      logActivity({
+        type: "admin_import_data", actorId: user.uid, actorName: adminName,
+        details: { updatedCount, skippedCount, fileName: file.name },
+      });
+
+      let msg = Tr.uploadSuccess(updatedCount);
+      if (skippedCount > 0) msg += " " + Tr.skippedRows(skippedCount);
+      showToast(msg, "success");
+    } catch (err) {
+      console.error("Upload error:", err);
+      showToast(Tr.uploadError, "error");
+    } finally {
+      setExcelBusy(false);
+    }
+  }, [users, Tr, user, adminName, showToast]);
 
   /* ── Log filters ── */
   const filteredLogs = logs.filter(log => {
@@ -1332,6 +1718,39 @@ export default function AdminPage() {
       {/* ══ DATA TAB ══ */}
       {!loading && tab === "data" && (
         <>
+          {/* ── Excel import/export buttons ── */}
+          {(profile?.adminPermissions?.canExportData || profile?.isAdmin) && (
+            <div style={{ display:"flex", gap:"10px", marginBottom:"1.25rem", flexWrap:"wrap", alignItems:"center" }}>
+              <button
+                style={{ ...S.excelBtn, opacity: excelBusy ? 0.6 : 1 }}
+                disabled={excelBusy}
+                onClick={() => setExportModalOpen(true)}
+                onMouseEnter={e => { if (!excelBusy) e.currentTarget.style.background = "#dbeafe"; }}
+                onMouseLeave={e => { e.currentTarget.style.background = "#eff6ff"; }}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                {excelBusy ? Tr.downloading : Tr.downloadExcel}
+              </button>
+              <button
+                style={{ ...S.excelBtnUpload, opacity: excelBusy ? 0.6 : 1 }}
+                disabled={excelBusy}
+                onClick={() => fileInputRef.current?.click()}
+                onMouseEnter={e => { if (!excelBusy) e.currentTarget.style.background = "#dcfce7"; }}
+                onMouseLeave={e => { e.currentTarget.style.background = "#f0fdf4"; }}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                {excelBusy ? Tr.uploading : Tr.uploadData}
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".xlsx,.xls,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+                style={{ display: "none" }}
+                onChange={handleUploadExcel}
+              />
+            </div>
+          )}
+
           {/* Stat summary row */}
           <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fit,minmax(180px,1fr))", gap:"1rem", marginBottom:"1.5rem" }}>
             {[
@@ -1757,6 +2176,25 @@ export default function AdminPage() {
           Tr={Tr}
           onSave={(perms) => doUpdatePerms(editPermsTarget, perms)}
           onCancel={() => setEditPermsTarget(null)}
+        />
+      )}
+
+      {/* ── Export field-selection modal ── */}
+      {exportModalOpen && (
+        <ExportFieldsModal
+          busy={excelBusy}
+          Tr={Tr}
+          onExport={handleDownloadExcel}
+          onCancel={() => { if (!excelBusy) setExportModalOpen(false); }}
+        />
+      )}
+
+      {/* ── Toast notification ── */}
+      {toast && (
+        <Toast
+          message={toast.message}
+          variant={toast.variant}
+          onClose={() => setToast(null)}
         />
       )}
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import LandingPage from "./LandingPage";
 import CompleteProfilePage from "./CompleteProfilePage";
 import OtpVerificationPage from "./OtpVerificationPage";
 import DashboardPage from "./DashboardPage";
+import AuthGateModal from "./GuestGate";
 
 /* Global cursor trail — smooth comet tail */
 function CursorTrail() {
@@ -187,16 +188,17 @@ function LoadingScreen() {
 }
 
 function AppContent() {
-  const { user, profile, loading } = useAuth();
+  const { user, profile, loading, isGuest, enterGuest, authRequest, clearAuthRequest } = useAuth();
   const [showAuth, setShowAuth]         = useState(false);
   const [showLoginIntro, setShowLoginIntro] = useState(false);
   const prevUserRef = useRef(null);
 
-  /* Show intro once per session when user transitions from null → logged-in */
+  /* Show intro once per session when user transitions from null → logged-in.
+     Skip it for anonymous guests — they didn't "log in". */
   useEffect(() => {
     if (!loading) {
       const wasLoggedOut = prevUserRef.current === null;
-      const isNowLoggedIn = !!user;
+      const isNowLoggedIn = !!user && !user.isAnonymous;
       if (wasLoggedOut && isNowLoggedIn && !sessionStorage.getItem("login_intro_done")) {
         sessionStorage.setItem("login_intro_done", "1");
         setShowLoginIntro(true);
@@ -212,9 +214,15 @@ function AppContent() {
   }
 
   if (!user) {
-    if (showAuth) return <AuthPage onBack={() => setShowAuth(false)} />;
-    return <LandingPage onLogin={() => setShowAuth(true)} />;
+    /* Guest tapped Log In / Sign Up inside the gate → open AuthPage on that tab. */
+    if (authRequest) return <AuthPage initialTab={authRequest} onBack={clearAuthRequest} />;
+    if (showAuth)    return <AuthPage onBack={() => setShowAuth(false)} />;
+    return <LandingPage onLogin={() => setShowAuth(true)} onExplore={enterGuest} />;
   }
+
+  /* Anonymous guest → straight into the (read-only) dashboard, bypassing the
+     Complete-Profile / OTP guards that only apply to real accounts. */
+  if (isGuest) return <DashboardPage />;
 
   if (profile === null) return <CompleteProfilePage />;
 
@@ -230,6 +238,7 @@ export default function App() {
         <AuthProvider>
           <CursorTrail />
           <AppContent />
+          <AuthGateModal />
         </AuthProvider>
       </LanguageProvider>
     </ThemeProvider>

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, useCallback } from "react";
-import { onAuthStateChanged, signOut, getRedirectResult } from "firebase/auth";
+import { onAuthStateChanged, signOut, signInAnonymously, getRedirectResult } from "firebase/auth";
 import { doc, getDoc, updateDoc } from "firebase/firestore";
 import { auth, db } from "./firebase";
 
@@ -9,6 +9,16 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(undefined);
   const [profile, setProfile] = useState(undefined);
   const [loading, setLoading] = useState(true);
+
+  /* ── Guest mode (Firebase Anonymous Auth) + auth gate ──
+     A guest is a real-but-anonymous Firebase session. This satisfies the
+     `isAuth()` Firestore rules (so guests can READ the community) while we
+     treat `user.isAnonymous` as the read-only "guest" flag throughout the app. */
+  const [gateOpen, setGateOpen]       = useState(false);   // is the "create account" modal showing?
+  const [authRequest, setAuthRequest] = useState(null);    // null | "login" | "signup"
+
+  const isGuest = user?.isAnonymous === true;
+
   useEffect(() => {
     /* Process the result of signInWithRedirect (Google sign-in).
        This resolves silently if there's no pending redirect. */
@@ -19,7 +29,10 @@ export function AuthProvider({ children }) {
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       setLoading(true);
       setUser(firebaseUser ?? null);
-      if (firebaseUser) {
+
+      /* Anonymous guests have no Firestore profile — skip the profile fetch
+         entirely so they're never routed to "Complete Profile". */
+      if (firebaseUser && !firebaseUser.isAnonymous) {
         const snap = await getDoc(doc(db, "users", firebaseUser.uid));
         if (snap.exists()) {
           let profileData = snap.data();
@@ -44,6 +57,13 @@ export function AuthProvider({ children }) {
       } else {
         setProfile(null);
       }
+
+      /* A real (non-anonymous) sign-in clears any pending auth request / gate. */
+      if (firebaseUser && !firebaseUser.isAnonymous) {
+        setAuthRequest(null);
+        setGateOpen(false);
+      }
+
       setLoading(false);
     });
     return unsubscribe;
@@ -52,7 +72,7 @@ export function AuthProvider({ children }) {
   const refreshProfile = useCallback(async () => {
     // Use auth.currentUser to always get the fresh user, avoiding stale closure
     const currentUser = auth.currentUser;
-    if (currentUser) {
+    if (currentUser && !currentUser.isAnonymous) {
       const snap = await getDoc(doc(db, "users", currentUser.uid));
       setProfile(snap.exists() ? snap.data() : null);
     }
@@ -63,8 +83,53 @@ export function AuthProvider({ children }) {
     setProfile(null);
   };
 
+  /* Enter guest mode: open an anonymous Firebase session so reads pass the
+     `isAuth()` rules. onAuthStateChanged then flips us into guest dashboard. */
+  const enterGuest = useCallback(async () => {
+    try {
+      await signInAnonymously(auth);
+    } catch (err) {
+      /* Most likely cause: Anonymous sign-in is not enabled in the Firebase
+         console (Authentication → Sign-in method → Anonymous). Fail soft so the
+         landing page stays usable rather than throwing an unhandled rejection. */
+      console.error("Guest sign-in failed (is Anonymous auth enabled?):", err.code, err.message);
+    }
+  }, []);
+
+  /* Leave guest mode (e.g. guest taps "logout"): drop the anonymous session
+     and fall back to the landing page. */
+  const exitGuest = useCallback(async () => {
+    setGateOpen(false);
+    if (auth.currentUser?.isAnonymous) {
+      await signOut(auth);
+    }
+  }, []);
+
+  /* The read-only gate modal. */
+  const openGate  = useCallback(() => setGateOpen(true), []);
+  const closeGate = useCallback(() => setGateOpen(false), []);
+
+  /* Guest tapped "Log In" / "Sign Up" inside the gate: tear down the anonymous
+     session and signal App to render <AuthPage> on the requested tab. */
+  const requestAuth = useCallback(async (mode = "login") => {
+    setGateOpen(false);
+    setAuthRequest(mode);
+    if (auth.currentUser?.isAnonymous) {
+      await signOut(auth);
+    }
+  }, []);
+
+  const clearAuthRequest = useCallback(() => setAuthRequest(null), []);
+
   return (
-    <AuthContext.Provider value={{ user, profile, loading, logout, refreshProfile }}>
+    <AuthContext.Provider
+      value={{
+        user, profile, loading, logout, refreshProfile,
+        isGuest, enterGuest, exitGuest,
+        gateOpen, openGate, closeGate,
+        authRequest, requestAuth, clearAuthRequest,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -541,8 +541,8 @@ function SignUpForm({ onSwitchTab, Tr, dir }) {
 }
 
 /* ─── MAIN ─── */
-export default function AuthPage({ onBack }) {
-  const [tab, setTab] = useState("login");
+export default function AuthPage({ onBack, initialTab = "login" }) {
+  const [tab, setTab] = useState(initialTab);
   const { lang, isRTL, setLang } = useLang();
   const Tr = AUTH_T[lang] || AUTH_T.he;
   const dir = isRTL ? "rtl" : "ltr";

--- a/frontend/src/CommunityPage.jsx
+++ b/frontend/src/CommunityPage.jsx
@@ -8,6 +8,7 @@ import {
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { db, storage } from "./firebase";
 import { useAuth } from "./AuthContext";
+import { useGuestGate } from "./GuestGate";
 import { logActivity } from "./activityLogger";
 
 /* ── Helpers ── */
@@ -143,6 +144,8 @@ function CommentItem({ comment, currentUid, isAdmin, onDelete, onEdit }) {
 /* ── Post card ── */
 function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfile, onMessage }) {
   const { t } = useLang();
+  const { isGuest } = useAuth();
+  const guard = useGuestGate();
   const [liked,    setLiked]    = useState((post.likedBy || []).includes(currentUser?.uid));
   const [likes,    setLikes]    = useState(post.likesCount || (post.likedBy?.length || 0));
   const [comments, setComments] = useState([]);
@@ -375,7 +378,7 @@ function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfil
         display: "flex", alignItems: "center", gap: 2,
       }}>
         <button
-          onClick={handleLike}
+          onClick={guard(handleLike)}
           style={{
             display: "flex", alignItems: "center", gap: 6,
             padding: "7px 14px", borderRadius: "var(--r-full)",
@@ -414,9 +417,9 @@ function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfil
           <span>{t.community.comment}</span>
         </button>
 
-        {currentUser && post.authorId !== currentUser.uid && (
+        {(isGuest || (currentUser && post.authorId !== currentUser.uid)) && (
           <button
-            onClick={() => onMessage?.(post.authorId)}
+            onClick={guard(() => onMessage?.(post.authorId))}
             style={{
               display: "flex", alignItems: "center", gap: 6,
               padding: "7px 14px", borderRadius: "var(--r-full)",
@@ -434,9 +437,9 @@ function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfil
           </button>
         )}
 
-        {currentUser && post.authorId !== currentUser.uid && (
+        {(isGuest || (currentUser && post.authorId !== currentUser.uid)) && (
           <button
-            onClick={() => setShowRepostModal(true)}
+            onClick={guard(() => setShowRepostModal(true))}
             style={{
               display: "flex", alignItems: "center", gap: 6,
               padding: "7px 14px", borderRadius: "var(--r-full)",
@@ -507,13 +510,13 @@ function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfil
             />
           ))}
 
-          {currentUser && (
+          {(currentUser || isGuest) && (
             <div style={{ display: "flex", gap: 8, marginTop: 12, alignItems: "center" }}>
               <div style={{ flex: 1 }}>
                 <input
                   value={commentText}
                   onChange={(e) => setCommentText(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleComment(); } }}
+                  onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); guard(handleComment)(e); } }}
                   placeholder={t.community.commentPlaceholder}
                   style={{
                     width: "100%", padding: "10px 14px",
@@ -527,7 +530,7 @@ function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfil
                 />
               </div>
               <button
-                onClick={handleComment}
+                onClick={guard(handleComment)}
                 disabled={!commentText.trim() || postingComment}
                 style={{
                   width: 36, height: 36, borderRadius: "50%",
@@ -554,6 +557,8 @@ function PostCard({ post, currentUser, isAdmin, onDelete, onRepost, onViewProfil
 /* ── Compose box ── */
 function ComposeBox({ currentUser, profile, onPost }) {
   const { t } = useLang();
+  const { isGuest } = useAuth();
+  const guard = useGuestGate();
   const [text, setText]       = useState("");
   const [files, setFiles]     = useState([]);
   const [posting, setPosting] = useState(false);
@@ -595,7 +600,10 @@ function ComposeBox({ currentUser, profile, onPost }) {
     } finally { setPosting(false); }
   };
 
+  /* For guests the button is always "active" so the very first tap opens the
+     auth gate (instead of sitting disabled). hasContent still drives real users. */
   const hasContent = text.trim() || files.length > 0;
+  const canSubmit  = isGuest || hasContent;
 
   return (
     <div
@@ -648,7 +656,7 @@ function ComposeBox({ currentUser, profile, onPost }) {
           )}
 
           <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 12, paddingTop: 12, borderTop: "1px solid var(--border)" }}>
-            <button onClick={() => fileRef.current.click()} style={{
+            <button onClick={guard(() => fileRef.current.click())} style={{
               display: "flex", alignItems: "center", gap: 6,
               padding: "7px 13px", borderRadius: "var(--r-full)",
               background: "var(--bg-secondary)", border: "1px solid var(--border)",
@@ -667,16 +675,16 @@ function ComposeBox({ currentUser, profile, onPost }) {
             <div style={{ flex: 1 }} />
 
             <button
-              onClick={handlePost}
-              disabled={!hasContent || posting}
+              onClick={guard(handlePost)}
+              disabled={!canSubmit || posting}
               style={{
                 padding: "9px 22px", borderRadius: "var(--r-full)",
-                background: hasContent ? "linear-gradient(135deg, var(--brand), var(--brand-dark))" : "var(--bg-tertiary)",
-                color: hasContent ? "#fff" : "var(--text-muted)",
+                background: canSubmit ? "linear-gradient(135deg, var(--brand), var(--brand-dark))" : "var(--bg-tertiary)",
+                color: canSubmit ? "#fff" : "var(--text-muted)",
                 border: "none", fontSize: 13, fontWeight: 700,
-                cursor: hasContent ? "pointer" : "default",
+                cursor: canSubmit ? "pointer" : "default",
                 transition: "all var(--t-fast)",
-                boxShadow: hasContent ? "0 6px 18px var(--brand-glow)" : "none",
+                boxShadow: canSubmit ? "0 6px 18px var(--brand-glow)" : "none",
                 letterSpacing: "0.02em",
               }}
             >

--- a/frontend/src/ConnectButton.jsx
+++ b/frontend/src/ConnectButton.jsx
@@ -13,10 +13,12 @@ import {
 } from "firebase/firestore";
 import { db } from "./firebase";
 import { useAuth } from "./AuthContext";
+import { useGuestGate } from "./GuestGate";
 import { useLang } from "./LanguageContext";
 
 export default function ConnectButton({ targetUserId, size = "md", onToggle }) {
-  const { user } = useAuth();
+  const { user, isGuest } = useAuth();
+  const guard = useGuestGate();
   const { t } = useLang();
 
   const [inNetwork, setInNetwork] = useState(false);
@@ -95,7 +97,7 @@ export default function ConnectButton({ targetUserId, size = "md", onToggle }) {
   };
 
   return (
-    <button style={style} onClick={handleToggle} disabled={loading}>
+    <button style={style} onClick={guard(handleToggle)} disabled={loading && !isGuest}>
       {inNetwork
         ? (t.network?.inNetwork  ?? "In Network")
         : (t.network?.joinNetwork ?? "Join Network")}

--- a/frontend/src/DashboardPage.jsx
+++ b/frontend/src/DashboardPage.jsx
@@ -406,7 +406,7 @@ function HomePage({ user, profile, onNavigate, onViewProfile }) {
 
 /* ── Main dashboard shell ── */
 export default function DashboardPage() {
-  const { user, profile, logout } = useAuth();
+  const { user, profile, logout, isGuest, exitGuest, openGate } = useAuth();
   const { lang, setLang, t, isRTL } = useLang();
   const { dark, toggleTheme } = useTheme();
 
@@ -417,6 +417,13 @@ export default function DashboardPage() {
   const [chatTarget, setChatTarget] = useState(null);
 
   const navigate = useCallback((s, options = {}) => {
+    /* Guests may browse Home / Community / Members and VIEW other members'
+       profiles (navigate with a userId). Account-only destinations — their own
+       profile/settings, DMs, admin — open the auth gate instead. */
+    if (isGuest && (s === "chat" || s === "admin" || (s === "profile" && !options.userId))) {
+      openGate();
+      return;
+    }
     localStorage.setItem("section", s);
     setSection(s);
     if (s === "profile") {
@@ -433,7 +440,7 @@ export default function DashboardPage() {
       if (prev[prev.length - 1] === s) return prev;
       return [...prev, s];
     });
-  }, []);
+  }, [isGuest, openGate]);
 
   const goBack = useCallback(() => {
     setNavHistory((prev) => {
@@ -449,7 +456,7 @@ export default function DashboardPage() {
   const canGoBack = navHistory.length > 1;
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || isGuest) return;   // guests have no users/{uid} doc to update
     const ref = doc(db, "users", user.uid);
     updateDoc(ref, { isOnline: true, lastSeen: new Date().toISOString() }).catch(() => {});
     const offline = () =>
@@ -463,7 +470,7 @@ export default function DashboardPage() {
       clearInterval(hb);
       offline();
     };
-  }, [user]);
+  }, [user, isGuest]);
 
   const initials = profile
     ? `${profile.firstName?.[0] || ""}${profile.lastName?.[0] || ""}`.toUpperCase()
@@ -574,7 +581,7 @@ export default function DashboardPage() {
           gap: "10px", paddingLeft: sidebarExpanded ? 8 : 0, paddingRight: sidebarExpanded ? 8 : 0 }}>
           <NavBtn
             item={{ id: "logout", label: t.nav.logout, icon: Icon.logout }}
-            active={false} badge={0} onClick={logout} expanded={sidebarExpanded}
+            active={false} badge={0} onClick={isGuest ? exitGuest : logout} expanded={sidebarExpanded}
           />
           <div style={{ position: "relative", cursor: "pointer",
             display: "flex", alignItems: "center", gap: 10,

--- a/frontend/src/GuestGate.jsx
+++ b/frontend/src/GuestGate.jsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect } from "react";
+import { useAuth } from "./AuthContext";
+import { useLang } from "./LanguageContext";
+
+/**
+ * useGuestGate — the single interception point for restricted actions.
+ *
+ * Wrap any action handler with the returned `guard`:
+ *
+ *     const guard = useGuestGate();
+ *     <button onClick={guard(handleLike)}>Like</button>
+ *
+ * For a guest, the click is intercepted entirely: default + propagation are
+ * stopped, NO underlying handler (and therefore no Firestore/API call) runs,
+ * and the "create an account" modal opens instead. For a real user the
+ * original handler runs untouched, receiving the same event/args.
+ */
+export function useGuestGate() {
+  const { isGuest, openGate } = useAuth();
+  return useCallback(
+    (handler) =>
+      (e, ...rest) => {
+        if (isGuest) {
+          e?.preventDefault?.();
+          e?.stopPropagation?.();
+          openGate();
+          return undefined;
+        }
+        return handler?.(e, ...rest);
+      },
+    [isGuest, openGate]
+  );
+}
+
+/* Tri-lingual copy — kept local so we don't touch the large LanguageContext. */
+const GATE_T = {
+  en: {
+    title: "Join the community",
+    body: "Create a free account to like, post, comment, repost, and connect with members.",
+    signup: "Create account",
+    login: "I already have an account",
+    later: "Keep browsing",
+  },
+  he: {
+    title: "הצטרפי לקהילה",
+    body: "צרי חשבון חינם כדי לתת לייק, לפרסם, להגיב, לשתף ולהתחבר לחברות הקהילה.",
+    signup: "יצירת חשבון",
+    login: "כבר יש לי חשבון",
+    later: "המשיכי לעיין",
+  },
+  ar: {
+    title: "انضمي إلى المجتمع",
+    body: "أنشئي حسابًا مجانيًا للإعجاب والنشر والتعليق وإعادة النشر والتواصل مع الأعضاء.",
+    signup: "إنشاء حساب",
+    login: "لدي حساب بالفعل",
+    later: "متابعة التصفح",
+  },
+};
+
+/**
+ * AuthGateModal — Instagram-style "you need an account" pop-up.
+ * Rendered once, globally (in App). Reads its open state from AuthContext, so
+ * closing it leaves the page underneath exactly where it was (it's a pure
+ * overlay — nothing unmounts, nothing refreshes).
+ */
+export default function AuthGateModal() {
+  const { gateOpen, closeGate, requestAuth } = useAuth();
+  const { lang, isRTL } = useLang();
+
+  /* Esc closes the gate. */
+  useEffect(() => {
+    if (!gateOpen) return;
+    const onKey = (e) => { if (e.key === "Escape") closeGate(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [gateOpen, closeGate]);
+
+  if (!gateOpen) return null;
+
+  const T = GATE_T[lang] || GATE_T.he;
+  const dir = isRTL ? "rtl" : "ltr";
+
+  return (
+    <div
+      onClick={closeGate}
+      style={{
+        position: "fixed", inset: 0, zIndex: 4000,
+        background: "rgba(74,31,61,0.45)",
+        backdropFilter: "blur(6px)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        padding: "1rem",
+        animation: "gate-fade 0.18s ease",
+        fontFamily: "'Figtree','Outfit',system-ui,sans-serif",
+        direction: dir,
+      }}
+    >
+      <style>{`
+        @keyframes gate-fade{from{opacity:0}to{opacity:1}}
+        @keyframes gate-pop{from{opacity:0;transform:translateY(14px) scale(0.96)}to{opacity:1;transform:none}}
+      `}</style>
+
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        style={{
+          position: "relative",
+          width: "100%", maxWidth: 380,
+          background: "var(--bg-primary)",
+          borderRadius: "var(--r-xl)",
+          boxShadow: "var(--shadow-xl)",
+          padding: "2rem 1.75rem 1.5rem",
+          textAlign: "center",
+          display: "flex", flexDirection: "column", alignItems: "center", gap: "0.35rem",
+          animation: "gate-pop 0.24s cubic-bezier(0.2,0.8,0.2,1)",
+        }}
+      >
+        {/* Close (×) */}
+        <button
+          onClick={closeGate}
+          aria-label="Close"
+          style={{
+            position: "absolute", top: 12, [isRTL ? "left" : "right"]: 12,
+            width: 30, height: 30, borderRadius: "50%",
+            border: "none", background: "var(--bg-tertiary)",
+            color: "var(--text-muted)", cursor: "pointer",
+            fontSize: 17, lineHeight: 1, display: "flex",
+            alignItems: "center", justifyContent: "center",
+            transition: "all var(--t-fast)",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; e.currentTarget.style.color = "var(--text-secondary)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = "var(--bg-tertiary)"; e.currentTarget.style.color = "var(--text-muted)"; }}
+        >×</button>
+
+        {/* Logo */}
+        <div style={{
+          width: 64, height: 64, borderRadius: "50%", marginBottom: "0.6rem",
+          background: "linear-gradient(135deg, var(--brand), var(--brand-dark))",
+          display: "flex", alignItems: "center", justifyContent: "center",
+          boxShadow: "0 8px 22px var(--brand-glow)", overflow: "hidden",
+        }}>
+          <img
+            src="/NewLogoNGO.png"
+            alt="BogrotNet"
+            onError={(e) => { e.currentTarget.style.display = "none"; }}
+            style={{ width: "100%", height: "100%", objectFit: "contain", padding: 6 }}
+          />
+        </div>
+
+        <h2 style={{
+          fontSize: 19, fontWeight: 800, color: "var(--text-primary)",
+          margin: 0, fontFamily: "'Outfit',sans-serif", letterSpacing: "-0.01em",
+        }}>{T.title}</h2>
+
+        <p style={{
+          fontSize: 13.5, color: "var(--text-muted)", lineHeight: 1.6,
+          margin: "0.25rem 0 1.1rem", maxWidth: 300,
+        }}>{T.body}</p>
+
+        {/* Primary: Sign Up */}
+        <button
+          onClick={() => requestAuth("signup")}
+          style={{
+            width: "100%", padding: "12px 0", borderRadius: "var(--r-full)",
+            background: "linear-gradient(135deg, var(--brand), var(--brand-dark))",
+            color: "#fff", border: "none", fontSize: 14, fontWeight: 700,
+            cursor: "pointer", boxShadow: "0 6px 18px var(--brand-glow)",
+            transition: "transform var(--t-fast), box-shadow var(--t-fast)",
+            fontFamily: "inherit",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.transform = "translateY(-1px)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.transform = ""; }}
+        >{T.signup}</button>
+
+        {/* Secondary: Log In */}
+        <button
+          onClick={() => requestAuth("login")}
+          style={{
+            width: "100%", padding: "11px 0", borderRadius: "var(--r-full)",
+            background: "transparent", color: "var(--brand-dark)",
+            border: "1.5px solid var(--border)", fontSize: 13.5, fontWeight: 700,
+            cursor: "pointer", marginTop: 8,
+            transition: "all var(--t-fast)", fontFamily: "inherit",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.borderColor = "var(--brand)"; e.currentTarget.style.background = "var(--brand-pale)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.borderColor = "var(--border)"; e.currentTarget.style.background = "transparent"; }}
+        >{T.login}</button>
+
+        {/* Tertiary: dismiss, stay on page */}
+        <button
+          onClick={closeGate}
+          style={{
+            background: "none", border: "none", color: "var(--text-muted)",
+            fontSize: 12.5, fontWeight: 600, cursor: "pointer",
+            marginTop: 12, padding: 4, fontFamily: "inherit",
+          }}
+        >{T.later}</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -1012,7 +1012,7 @@ function ScreenshotFlipGuide({ T, onLogin }) {
 /* ═══════════════════════════════════════════
    LANDING PAGE
 ═══════════════════════════════════════════ */
-export default function LandingPage({ onLogin }) {
+export default function LandingPage({ onLogin, onExplore }) {
   const { isRTL, lang, setLang } = useLang();
   const T   = LP[lang] ?? LP.he;
   const dir = isRTL ? "rtl" : "ltr";
@@ -1279,7 +1279,7 @@ export default function LandingPage({ onLogin }) {
               {rippling&&<span style={{position:"absolute",inset:0,margin:"auto",width:10,height:10,borderRadius:"50%",background:"rgba(255,255,255,0.45)",animation:"lp-ripple 0.65s ease-out forwards"}}/>}
               {T.join}
             </button>
-            <button onClick={onLogin} style={{
+            <button onClick={onExplore || onLogin} style={{
               background:"rgba(255,255,255,0.18)",color:C.white,
               border:"2px solid rgba(255,255,255,0.5)",
               padding:"13px 28px",borderRadius:999,

--- a/frontend/src/ProfilePage.jsx
+++ b/frontend/src/ProfilePage.jsx
@@ -8,6 +8,7 @@ import {
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { db, auth } from "./firebase";
 import { useAuth } from "./AuthContext";
+import { useGuestGate } from "./GuestGate";
 import { useLang } from "./LanguageContext";
 
 const storage = getStorage();
@@ -184,6 +185,7 @@ function PlainInput(props) {
 
 export default function ProfilePage({ viewUserId, onMessage }) {
   const { user, refreshProfile } = useAuth();
+  const guard = useGuestGate();
   const { t, isRTL } = useLang();
   const fileRef = useRef();
 
@@ -699,7 +701,7 @@ export default function ProfilePage({ viewUserId, onMessage }) {
 
             <div style={{ display:"flex", gap:"0.75rem", flexWrap:"wrap" }}>
               <button
-                onClick={handleMessageClick}
+                onClick={guard(handleMessageClick)}
                 style={{
                   padding:"12px 20px", borderRadius:"14px",
                   background:"#1d4896", color:"#fff", border:"none",

--- a/frontend/src/Supportpage.jsx
+++ b/frontend/src/Supportpage.jsx
@@ -237,11 +237,21 @@ const isOnline = (u) => {
 /* ─── Inject styles ─── */
 const styleTag = document.createElement("style");
 styleTag.textContent = `
+  .support-input {
+    background-color: var(--bg-secondary) !important;
+    color: var(--text-primary) !important;
+  }
   .support-input:focus {
     border-color: #4472b8 !important;
     box-shadow: 0 0 0 3px rgba(68,114,184,0.16) !important;
-    background: #fff !important;
+    background-color: var(--bg-secondary) !important;
     outline: none;
+  }
+  .support-input:-webkit-autofill,
+  .support-input:-webkit-autofill:hover,
+  .support-input:-webkit-autofill:focus {
+    -webkit-box-shadow: 0 0 0px 1000px var(--bg-secondary) inset !important;
+    -webkit-text-fill-color: var(--text-primary) !important;
   }
   .result-card:hover {
     transform: translateY(-2px);

--- a/frontend/src/Supportpage.jsx
+++ b/frontend/src/Supportpage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { collection, getDocs, addDoc, query, where, doc, updateDoc, deleteDoc } from "firebase/firestore";
 import { db } from "./firebase";
 import { useAuth } from "./AuthContext";
+import { useGuestGate } from "./GuestGate";
 import { useLang } from "./LanguageContext";
 import { logActivity } from "./activityLogger";
 
@@ -273,7 +274,8 @@ function MemberAvatar({ user, size = 46, fontSize = 15 }) {
 }
 
 export default function SupportPage({ onViewProfile, onMessage }) {
-  const { user } = useAuth();
+  const { user, isGuest } = useAuth();
+  const guard = useGuestGate();
   const { lang, isRTL } = useLang();
   const Tr = T[lang] || T.he;
 
@@ -302,15 +304,18 @@ export default function SupportPage({ onViewProfile, onMessage }) {
 
   useEffect(() => {
     if (!user) return;
-    Promise.all([
-      getDocs(collection(db, "users")),
-      getDocs(query(collection(db, "helpRequests"), where("fromUserId", "==", user.uid))),
-      getDocs(query(collection(db, "helpRequests"), where("toUserId",   "==", user.uid))),
-    ]).then(([usersSnap, sentSnap, recvSnap]) => {
+    /* Guests (anonymous) can read the member directory but have no help-request
+       history of their own — skip those queries for them. */
+    const tasks = [getDocs(collection(db, "users"))];
+    if (!isGuest) {
+      tasks.push(getDocs(query(collection(db, "helpRequests"), where("fromUserId", "==", user.uid))));
+      tasks.push(getDocs(query(collection(db, "helpRequests"), where("toUserId",   "==", user.uid))));
+    }
+    Promise.all(tasks).then(([usersSnap, sentSnap, recvSnap]) => {
       const docs = usersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-      const me   = docs.find((d) => d.id === user.uid);
+      const me   = isGuest ? null : docs.find((d) => d.id === user.uid);
       if (me) setSenderProfile(me);
-      const others = docs.filter((d) => d.id !== user.uid);
+      const others = isGuest ? docs : docs.filter((d) => d.id !== user.uid);
       setAllUsers(others);
       const sorted = [...others].sort((a, b) => {
         const ta = a.lastSeen ? new Date(a.lastSeen).getTime() : 0;
@@ -318,14 +323,16 @@ export default function SupportPage({ onViewProfile, onMessage }) {
         return tb - ta;
       });
       setRecommended(sorted.slice(0, 4));
-      const reqs = sentSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-      setSentRequests(reqs);
-      const reqMap = {};
-      reqs.forEach((r) => { reqMap[r.toUserId] = true; });
-      setRequested(reqMap);
-      setReceivedRequests(recvSnap.docs.map((d) => ({ id: d.id, ...d.data() })));
+      if (sentSnap && recvSnap) {
+        const reqs = sentSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setSentRequests(reqs);
+        const reqMap = {};
+        reqs.forEach((r) => { reqMap[r.toUserId] = true; });
+        setRequested(reqMap);
+        setReceivedRequests(recvSnap.docs.map((d) => ({ id: d.id, ...d.data() })));
+      }
     });
-  }, [user]);
+  }, [user, isGuest]);
 
   const openSuggest = () => {
     if (nameInputRef.current) {
@@ -769,7 +776,7 @@ export default function SupportPage({ onViewProfile, onMessage }) {
                         {!cantSendHelp(u) && (
                           <button className={requested[u.id]?"":"req-btn"}
                             style={{ ...(requested[u.id]?S.reqDoneBtn:S.reqBtn), flex:"none", padding:"6px 14px" }}
-                            onClick={() => handleRequest(u)}>
+                            onClick={guard(() => handleRequest(u))}>
                             {requested[u.id] ? Tr.sent : Tr.sendReq}
                           </button>
                         )}
@@ -816,7 +823,7 @@ export default function SupportPage({ onViewProfile, onMessage }) {
                     <button
                       className={requested[u.id] ? "" : "req-btn"}
                       style={requested[u.id] ? S.reqDoneBtn : S.reqBtn}
-                      onClick={() => handleRequest(u)}
+                      onClick={guard(() => handleRequest(u))}
                     >
                       {requested[u.id] ? Tr.sent : Tr.sendReq}
                     </button>
@@ -924,7 +931,7 @@ export default function SupportPage({ onViewProfile, onMessage }) {
                     style={requested[u.id]
                       ? { ...S.reqDoneBtn, width: "100%", padding: "6px 0", fontSize: "12px" }
                       : { ...S.reqBtn, width: "100%", padding: "6px 0", fontSize: "12px" }}
-                    onClick={(e) => { e.stopPropagation(); handleRequest(u); }}
+                    onClick={guard((e) => { e.stopPropagation(); handleRequest(u); })}
                   >
                     {requested[u.id] ? Tr.sent : Tr.sendReq}
                   </button>
@@ -1000,7 +1007,7 @@ export default function SupportPage({ onViewProfile, onMessage }) {
               {!cantSendHelp(selectedUser) && (
                 <button
                   style={requested[selectedUser.id] ? S.modalReqDoneBtn : S.modalReqBtn}
-                  onClick={() => handleRequest(selectedUser)}
+                  onClick={guard(() => handleRequest(selectedUser))}
                   onMouseOver={(e) => { if (!requested[selectedUser.id]) e.currentTarget.style.background = "#1d4896"; }}
                   onMouseOut={(e)  => { if (!requested[selectedUser.id]) e.currentTarget.style.background = "#4472b8"; }}
                 >


### PR DESCRIPTION
## Summary
- Fix invisible text in the **MEMBER NAME** search input on the Find Help page in dark mode (white-on-white). The input now uses theme variables (`--bg-secondary` / `--text-primary`) for base, focus, and autofill states.
- Resolve merge conflict in `Supportpage.jsx` (request-message feature) from prior merge.

## Verification
Drove a real Chrome browser (Playwright) against the exact CSS cascade:
- Default & focused: dark bg `rgb(20,20,22)` + light text `rgb(240,237,234)` — contrast gap 217, readable.
- Negative control with old CSS: focused bg `rgb(255,255,255)` — contrast gap 18, invisible (confirms the bug the fix removes).

Note: this branch (`edit`) is 4 commits ahead of `main` and also carries earlier accumulated work (GuestGate, AdminPage, AuthContext, etc.).

